### PR TITLE
Fix splitting algorithm for unknown characters

### DIFF
--- a/wordninja.py
+++ b/wordninja.py
@@ -51,7 +51,28 @@ class LanguageModel(object):
     # Returns a pair (match_cost, match_length).
     def best_match(i):
       candidates = enumerate(reversed(cost[max(0, i-self._maxword):i]))
-      return min((c + self._wordcost.get(s[i-k-1:i].lower(), 9e999), k+1) for k,c in candidates)
+      min_cost = float('inf')
+      best_k = 0
+
+      for k, c in candidates:
+          word = s[i-k-1:i].lower()
+          word_cost = self._wordcost.get(word)
+
+          if word_cost is None:
+              if len(word) == 1:
+                  # Use a high (but not infinite) penalty for unknown single characters to allow continuation of the algorithm.
+                  word_cost = 25
+              else:
+                  # Use a a very high penalty for unknown longer words to force splitting into known words.
+                  word_cost = 9e999
+
+          current_total_cost = c + word_cost
+
+          if current_total_cost < min_cost:
+              min_cost = current_total_cost
+              best_k = k + 1
+
+      return min_cost, best_k
 
     # Build the cost array.
     cost = [0]


### PR DESCRIPTION
This PR solve issue #10 by reducing the penalty-term and by not allowing the algorithm to choose a "one-time" payment strategy. A detailed explanation can be found in the issue thread.

The penalty-term of 25 was not chosen arbitrarily - it was chosen by taking the max cost a word can get assigned to into account. The max_cost can be calculated like this:

```math
\text{Cost}_{\text{max}} = \ln(N \cdot \ln (N))
```

If you set the max cost value to 25 and solve the equation, you get the result, that a dictionary would need to have more than roughly 3.3 billion entries to cross the penalty term that an unknown word would get.
A penalty term of 20 equals 28 million possible entries, but 25 is definitely on the save side, and works perfectly fine with the algorithm.

This took me quite some time to figure out, so I would appreciate it if this could be merged.


Fix #10